### PR TITLE
Use AwsBasicCredentials for introductory example

### DIFF
--- a/doc_source/credentials.rst
+++ b/doc_source/credentials.rst
@@ -208,7 +208,7 @@ credentials using |STS|, use this method to specify the credentials for AWS acce
 .. topic:: To explicitly supply credentials to an AWS client
 
    #. Instantiate a class that provides the :aws-java-class:`AwsCredentials <auth/credentials/AwsCredentials>`
-      interface, such as :aws-java-class:`AwsSessionCredentials <auth/credentials/AwsSessionCredentials>`. Supply
+      interface, such as :aws-java-class:`AwsBasicCredentials <auth/credentials/AwsBasicCredentials>`. Supply
       it with the AWS access key and secret key to use for the connection.
 
    #. Create an :aws-java-class:`StaticCredentialsProvider <auth/credentials/StaticCredentialsProvider>` with
@@ -220,10 +220,9 @@ The following example creates a new service client that uses credentials that yo
 
 .. code-block:: java
 
-   AwsSessionCredentials awsCreds = AwsSessionCredentials.create(
+   AwsBasicCredentials awsCreds = AwsBasicCredentials.create(
        "your_access_key_id_here",
-       "your_secret_key_id_here",
-       "your_session_token_here");
+       "your_secret_key_id_here");
 
    S3Client s32 = S3Client.builder()
                           .credentialsProvider(StaticCredentialsProvider.create(awsCreds))


### PR DESCRIPTION
Hi there! I'd like to suggest that this introductory example use AwsBasicCredentials, which can be instantiated with just an access key and secret key. This avoids the need for a developer just getting started to generate a session token.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
