### PR TITLE
snippet update in the documentation to Delete-Buckets

### DIFF
--- a/doc_source/examples-s3-buckets.adoc
+++ b/doc_source/examples-s3-buckets.adoc
@@ -147,7 +147,7 @@ use the `deleteObject` method on each object to delete it.
 
 [source,java]
 ----
-include::../../snippets/s3.java2.s3_bucket_ops.import.txt[]
+include::../../snippets/s3.java2.bucket_deletion.import.txt[]
 ----
 
 *Code*
@@ -156,14 +156,21 @@ First create an S3Client.
 
 [source,java]
 ----
-include::../../snippets/s3.java2.s3_bucket_ops.region.txt[]
+include::../../snippets/s3.java2.bucket_deletion.region.txt[]
 ----
 
 Delete all objects in the bucket.
 
 [source,java]
 ----
-include::../../snippets/s3.java2.s3_bucket_ops.delete_bucket.txt[]
+include::../../snippets/ss3.java2.bucket_deletion.delete_all_objects_bucket.txt[]
+----
+
+Delete the bucket.
+
+[source,java]
+----
+include::../../snippets/s3.java2.bucket_deletion.delete_bucket.txt[]
 ----
 
 See the
@@ -181,7 +188,7 @@ with a bucket name and pass it to the S3Client's `deleteBucket` method.
 
 [source,java]
 ----
-include::../../snippets/s3.java2.s3_bucket_ops.import.txt[]
+include::../../snippets/s3.java2.bucket_deletion.import.txt[]
 ----
 
 *Code*
@@ -190,23 +197,16 @@ First create an S3Client.
 
 [source,java]
 ----
-include::../../snippets/s3.java2.s3_bucket_ops.region.txt[]
-----
-
-Delete all objects in the bucket.
-
-[source,java]
-----
-include::../../snippets/s3.java2.delete_objects.main.txt[]
+include::../../snippets/s3.java2.bucket_deletion.region.txt[]
 ----
 
 Delete the bucket.
 
 [source,java]
 ----
-include::../../snippets/s3.java2.s3_bucket_ops.delete_bucket.txt[]
+include::../../snippets/s3.java2.bucket_deletion.delete_bucket.txt[]
 ----
 
 See the
-{url-awsdocs-github}aws-doc-sdk-examples/blob/master/javav2/example_code/s3/src/main/java/com/example/s3/S3BucketOps.java[complete example]
+{url-awsdocs-github}aws-doc-sdk-examples/blob/master/javav2/example_code/s3/src/main/java/com/example/s3/S3BucketDeletion.java[complete example]
 on GitHub.


### PR DESCRIPTION
…t does not match the example.

*Issue #, if available:*

*Description of changes:*

In the documentation[1] about delete all objects, it is pointed to a different example than described.

this change depends on the PR [2];

[1] https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/examples-s3-buckets.html#delete-bucket
[2] https://github.com/awsdocs/aws-doc-sdk-examples/pull/3168

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
