### PR TITLE
Update transfer-manager.md

### DIFF
--- a/doc_source/transfer-manager.md
+++ b/doc_source/transfer-manager.md
@@ -114,7 +114,7 @@ Download download =
 To capture the response, use a [http://docs.aws.amazon.com/sdk-for-java/latest/reference/software/amazon/awssdk/transfer/s3/CompletedDownload.html](http://docs.aws.amazon.com/sdk-for-java/latest/reference/software/amazon/awssdk/transfer/s3/CompletedDownload.html) object\.
 
 ```
-CompletedDownload completedDownload = download.completionFuture().join();
+CompletedFileDownload completedDownload = download.completionFuture().join();
 
 System.out.println("Content length: "+ completedDownload.response().contentLength());
 ```


### PR DESCRIPTION
Return type of completionFuture seems to have changed since this was written.

*Issue #, if available:*

*Simply changed to CompletedFileDownload instead of CompletedDownload*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
