### PR TITLE
EnvironmentVariableCredentialsProvider constructor

### DIFF
--- a/doc_source/lambda-optimize-starttime.md
+++ b/doc_source/lambda-optimize-starttime.md
@@ -29,7 +29,7 @@ Using this credentials provider enables the code to be used in Lambda functions,
 ```
 S3Client client = S3Client.builder()
        .region(Region.US_WEST_2)
-       .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
+       .credentialsProvider(new EnvironmentVariableCredentialsProvider())
        .httpClient(UrlConnectionHttpClient.builder().build())
        .build();
 ```


### PR DESCRIPTION
*Issue #, if available:* none

*Description of changes:*
Fixing the reference to `EnvironmentVariableCredentialsProvider`. At least in `1.2.305` I fail to see a static method called `create()`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
