### PR TITLE
Update get-started.md for Java SDK Tutorial

### DIFF
--- a/doc_source/get-started.md
+++ b/doc_source/get-started.md
@@ -270,7 +270,7 @@ After the project is created and contains the example class, build and run the a
 
 When you run the application, it uploads a new a text file to a new bucket in Amazon S3\. Afterward, it will also delete the file and bucket\.
 
-1. In `App.java`, comment out the line `cleanUp(s3, bucket, key);` and save the file\.
+1. In `Handler.java`, comment out the line `cleanUp(s3, bucket, key);` and save the file\.
 
 1. Rebuild the project by running `mvn package`\.
 


### PR DESCRIPTION
Issue # N/A

## Within Step 4 : Build and Run the Application

The tutorial instructs the user to comment out the `cleanUp(s3Client, bucket, key)` command in the `App.java` implementation file to see their newly created s3 bucket. `App.java`does not contain the `cleanUp(s3Client, bucket, key)` call. This is contained in the `Handler.java` implementation file. 

This will clear up confusion for any future users. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
